### PR TITLE
Add `styles.css` to copied files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.iml
 .idea
 
+# Emacs
+.projectile
+
 # npm
 node_modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 17.5.1
+
+- Copy `styles.css` when building
+
 ## 17.5.0
 
 - Ensure not-empty pluginId

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-dev-utils",
-  "version": "17.5.0",
+  "version": "17.5.1",
   "description": "This is the collection of useful functions that you can use for your Obsidian plugin development",
   "keywords": [
     "obsidian"

--- a/src/scripts/esbuild/ObsidianPluginBuilder.ts
+++ b/src/scripts/esbuild/ObsidianPluginBuilder.ts
@@ -114,7 +114,8 @@ export async function buildObsidianPlugin(options: BuildObsidianPluginOptions): 
   await mkdir(distDir, { recursive: true });
 
   const distFileNames = [
-    ObsidianPluginRepoPaths.ManifestJson
+    ObsidianPluginRepoPaths.ManifestJson,
+    ObsidianPluginRepoPaths.StylesCss,
   ];
   if (!isProductionBuild) {
     await writeFile(join(distDir, ObsidianPluginRepoPaths.HotReload), '', 'utf-8');


### PR DESCRIPTION
The [plugin generator](https://github.com/mnaoumov/generator-obsidian-plugin) creates a `styles.css` file on the top level, so my assumption is the intent is for that file to be included in the files which get copied to the `dist` directory. It's fairly straightforward to treat it similarly to `manifest.json`, but I don't use sass so am uncertain if it will play nicely with the logic building from that.